### PR TITLE
Fix next and prev arrows

### DIFF
--- a/js/site.js
+++ b/js/site.js
@@ -56,6 +56,22 @@ function nextVideo(){
 	}
 	
 }
+
+function navCheck(){
+  var url = window.location.href;
+  $( "nav li" ).each(function() {
+    $(this).removeClass('active');
+  });
+  if(url == "http://ryandecarlo.com/staging/"){
+    $('nav li.news').addClass('pact');
+
+
+  } else if(url == "http://ryandecarlo.com/staging/work.php"){
+    $('nav li.work').addClass('pact');
+  }
+  $("#sb-wrapper").removeAttr("class");
+}
+
 function goShowReels(vid){
 				
 				$( "#sb-body-inner iframe" ).remove();
@@ -333,21 +349,6 @@ function(e) {
 		}
 	});
 	var s = function() {
-		var url = window.location.href;
-		
-		function navCheck(){
-			$( "nav li" ).each(function() {
-				$(this).removeClass('active');
-			});
-			if(url == "http://ryandecarlo.com/staging/"){
-				$('nav li.news').addClass('pact');
-				
-				
-			} else if(url == "http://ryandecarlo.com/staging/work.php"){
-				$('nav li.work').addClass('pact');
-			}
-			$("#sb-wrapper").removeAttr("class");
-		}
 		
 		function myScroll(){
 			$("#bfContainer").mCustomScrollbar();

--- a/js/site.js
+++ b/js/site.js
@@ -26,7 +26,28 @@ function veovidfunc(vid){
 	$("#iframe-container").attr('src', frameUrl);
 	
 }
-function prevVideo(){
+
+function isCurrentPageShowReels() {
+  return $("nav ul li.showreels").hasClass("active");
+}
+
+function prevVideo() {
+  if(isCurrentPageShowReels()) {
+    prevVideoForShowReel();
+  } else {
+    Shadowbox.previous();
+  }
+}
+
+function nextVideo() {
+  if(isCurrentPageShowReels()) {
+    nextVideoForShowReel();
+  } else {
+    Shadowbox.next();
+  }
+}
+
+function prevVideoForShowReel(){
 	
 	if($(".animation-reel").hasClass("active")){
 		veovidfunc(2);
@@ -41,7 +62,7 @@ function prevVideo(){
 	}
 	
 }
-function nextVideo(){
+function nextVideoForShowReel(){
 	
 	if($(".motion-design").hasClass("active")){
 		veovidfunc(2);


### PR DESCRIPTION
1. The next and prev buttons seem to be hard wired to a nextVideo() and prevVideo() globally defined function. That function was defined only for use on the show reels page. I preserved that functionality, and when not on the showreels page i made calls to `Shadowbox.next() and Shadowbox.prev()` which seem to work fine!
2. I can't tell if the navCheck() fix actually fixes anything other than the error in the console. Doesn't technically need to be a part of this pull request, but i guess we may as well fix it now.
